### PR TITLE
Allow external config file

### DIFF
--- a/src/build/NArrange.PreBuild.targets
+++ b/src/build/NArrange.PreBuild.targets
@@ -3,10 +3,12 @@
   <PropertyGroup>
     <BuildDependsOn>NArrange;$(BuildDependsOn)</BuildDependsOn>
     <RebuildDependsOn>NArrange;$(RebuildDependsOn)</RebuildDependsOn>
+    <NArrangePreBuildConfig></NArrangePreBuildConfig>
   </PropertyGroup>
 
   <Target Name="NArrange">
-    <Exec Command="%22$(MSBuildThisFileDirectory)..\tools\narrange-console.exe%22 %22$(ProjectPath)%22" />
+    <Exec Command="%22$(MSBuildThisFileDirectory)..\tools\narrange-console.exe%22 %22$(ProjectPath)%22" Condition="$(NArrangePreBuildConfig) == ''" />
+    <Exec Command="%22$(MSBuildThisFileDirectory)..\tools\narrange-console.exe%22 %22$(ProjectPath)%22 /c:%22$(NArrangePreBuildConfig)%22" Condition="$(NArrangePreBuildConfig) != ''" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Example to use: (assuming the config is in the project root)

``` xml
  <Import Project="..\packages\NArrange.PreBuild.0.2.9.1\build\NArrange.PreBuild.targets" Condition="Exists('..\packages\NArrange.PreBuild.0.2.9.1\build\NArrange.PreBuild.targets')" />
  <PropertyGroup>
    <NArrangePreBuildConfig>..\MyProject.NArrange.Config.xml</NArrangePreBuildConfig>
  </PropertyGroup>
```
